### PR TITLE
fix: correct role name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ module "organizations_account" {
   email  = "complete@example.com"
 
   iam_user_access_to_billing = "DENY"
-  role_name                  = "OrganizationAccoLuntAccessRole"
+  role_name                  = "OrganizationAccountAccessRole"
   enabled                    = true
 }
 ```
@@ -54,7 +54,7 @@ module "organizations_account" {
 | name                       | A friendly name for the member account.                                                           | string |                -                 |   yes    |
 | enabled                    | Set to false to prevent the module from creating anything.                                        | string |              `true`              |    no    |
 | iam_user_access_to_billing | If set to ALLOW, the new account enables IAM users to access account billing information.         | string |             `ALLOW`              |    no    |
-| role_name                  | The name of an IAM role that Organizations automatically preconfigures in the new member account. | string | `OrganizationAccoLuntAccessRole` |    no    |
+| role_name                  | The name of an IAM role that Organizations automatically preconfigures in the new member account. | string | `OrganizationAccountAccessRole` |    no    |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,6 +4,6 @@ module "organizations_account" {
   email  = "complete@example.com"
 
   iam_user_access_to_billing = "DENY"
-  role_name                  = "OrganizationAccoLuntAccessRole"
+  role_name                  = "OrganizationAccountAccessRole"
   enabled                    = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "iam_user_access_to_billing" {
 }
 
 variable "role_name" {
-  default     = "OrganizationAccoLuntAccessRole"
+  default     = "OrganizationAccountAccessRole"
   type        = "string"
   description = "The name of an IAM role that Organizations automatically preconfigures in the new member account."
 }


### PR DESCRIPTION
This PR corrects a typo on the role name created by the module